### PR TITLE
Small fixes to documentation text

### DIFF
--- a/doc/tokyonight.txt
+++ b/doc/tokyonight.txt
@@ -128,7 +128,7 @@ style.
  - lightline: https://github.com/itchyny/lightline.vim
 
 ==============================================================================
-4. Ports						*tokyonight-terminal*
+4. Ports						*tokyonight-ports*
 
 Alacritty by zatchheems:
 https://github.com/zatchheems/tokyo-night-alacritty-theme

--- a/doc/tokyonight.txt
+++ b/doc/tokyonight.txt
@@ -65,11 +65,6 @@ Supported options can be controlled by setting global variables (|g:|).
 Boolean options are set with numbers `1` or `0` for true and false,
 respectively. Options should be placed before setting the colorscheme.
 
- *g:neodark#background*		{string} Default: ''
-				Hex color value used as custom background. >
-				    let g:neodark#background = '#202020'
-<
-
  *g:tokyonight_style*		{string} Default: `'night'`
 				Available values: `'night'`, `'storm'`.
 				Customize the style of this color scheme.

--- a/doc/tokyonight.txt
+++ b/doc/tokyonight.txt
@@ -111,7 +111,7 @@ respectively. Options should be placed before setting the colorscheme.
 
 ==============================================================================
 3. Airline and lightline Themes				*tokyonight-statusline*
-				      *tokyonight-airline* *tokyonight-lightline*
+				     *tokyonight-airline* *tokyonight-lightline*
 
 Themes for |Airline| and |lightline| are included. To enable in lightline: >
 


### PR DESCRIPTION
@ghifarit53, I'm sorry to pollute your PRs with yet another one but I just noticed I made two mistakes:

 - I used as a template for describing options another documentation I wrote some years ago. I just noticed I left the template text sitting there on yours.
 - A section link was broken due to a typo on its name.

Sorry for this inconvenience.