### PR TITLE
[add] airline term's color palette

### DIFF
--- a/autoload/airline/themes/tokyonight.vim
+++ b/autoload/airline/themes/tokyonight.vim
@@ -51,3 +51,7 @@ let g:airline#themes#tokyonight#palette.insert = s:tokyonight_color_map(s:airlin
 let g:airline#themes#tokyonight#palette.replace = s:tokyonight_color_map(s:airline_mode_replace)
 let g:airline#themes#tokyonight#palette.inactive = s:tokyonight_color_map(s:airline_mode_inactive)
 let g:airline#themes#tokyonight#palette.visual = s:tokyonight_color_map(s:airline_mode_visual)
+let g:airline#themes#tokyonight#palette.terminal = s:tokyonight_color_map(s:airline_mode_insert)
+let g:airline#themes#tokyonight#palette.normal.airline_term = s:airline_statusline
+let g:airline#themes#tokyonight#palette.terminal.airline_term = s:airline_statusline
+let g:airline#themes#tokyonight#palette.visual.airline_term = s:airline_statusline


### PR DESCRIPTION
Hello, maintainer.
Thanks for creating great Vim's colorscheme.
I love this colorscheme.

By the way, I've updated the color scheme in the terminal section of the vim-airline.
This is expected to improve the user interface.
This uses the same green color scheme as the insert mode color scheme.

## before behaovor

- normal mode

<img width="569" alt="スクリーンショット 2020-11-12 2 15 58" src="https://user-images.githubusercontent.com/36619465/98842675-4580f500-248d-11eb-81a7-ebe3893dcb79.png">

- terminal mode

<img width="345" alt="スクリーンショット 2020-11-12 2 15 26" src="https://user-images.githubusercontent.com/36619465/98842651-3a2dc980-248d-11eb-9101-2be5897eb0c0.png">

## after behavior

- normal mode

<img width="569" alt="スクリーンショット 2020-11-12 2 15 58" src="https://user-images.githubusercontent.com/36619465/98842696-4b76d600-248d-11eb-9102-c52b07f84451.png">

- terminal mode

<img width="569" alt="スクリーンショット 2020-11-12 2 14 39" src="https://user-images.githubusercontent.com/36619465/98842612-2c784400-248d-11eb-9c88-703c104553a9.png">


